### PR TITLE
Escaped "%" in Rd documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Installation
 
-**dmatch** relies on the following R packages: **Rcpp**, **RcppArmadillo**, **mvtnorm**, **RcppEigen**, **irlba**. All packagess are hosted on CRAN.
+**dmatch** relies on the following R packages: **Rcpp**, **RcppArmadillo**, **mvtnorm**, **RcppEigen**, **irlba**. All packages are hosted on CRAN.
 
 ```r
 install.packages("Rcpp")

--- a/man/run_alignment_by_2D.Rd
+++ b/man/run_alignment_by_2D.Rd
@@ -12,7 +12,7 @@ run_alignment_by_2D(object, quantile = 0.95, K = 30, selected = NULL,
 
 \item{K}{The number of PCs for correcting batch effects}
 
-\item{NCell}{The smallest number of cells that a selected cluster should have. Default is 100, and recommend no less than 5% of the sample size}
+\item{NCell}{The smallest number of cells that a selected cluster should have. Default is 100, and recommend no less than 5\% of the sample size}
 }
 \value{
 A dmatch class object which have slots storing raw.data, batch.id, PCA, and more information


### PR DESCRIPTION
Escaped "%" character in man/run_alignment_by_2D.Rd, line 15 to allow package installation.